### PR TITLE
Update filter for score (JUST MERGE, I ADD TESTS LATER)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CHAMPION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RANK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCORE;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -22,6 +23,7 @@ import seedu.address.model.person.Rank;
 import seedu.address.model.person.RankContainsKeywordsPredicate;
 import seedu.address.model.person.Role;
 import seedu.address.model.person.RoleContainsKeywordsPredicate;
+import seedu.address.model.person.ScoreInRangePredicate;
 
 /**
  * Edits the details of an existing person in the address book.
@@ -37,15 +39,18 @@ public class FilterCommand extends Command {
             + "[" + PREFIX_RANK + "RANK]... "
             + "[" + PREFIX_ROLE + "ROLE]... "
             + "[" + PREFIX_CHAMPION + "CHAMPION]... "
+            + "[" + PREFIX_SCORE + "SCORE] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_RANK + "Diamond "
-            + PREFIX_CHAMPION + "Yasuo";
+            + PREFIX_CHAMPION + "Yasuo"
+            + PREFIX_SCORE + "2.4";
 
     public static final String MESSAGE_NOT_FILTERED = "At least one field to filter must be provided.";
 
     private final RankContainsKeywordsPredicate rankPredicate;
     private final RoleContainsKeywordsPredicate rolePredicate;
     private final ChampionContainsKeywordsPredicate championPredicate;
+    private final ScoreInRangePredicate scorePredicate;
 
     private final FilterPersonDescriptor filterPersonDescriptor;
 
@@ -58,13 +63,14 @@ public class FilterCommand extends Command {
         this.rankPredicate = new RankContainsKeywordsPredicate(List.of(filterPersonDescriptor.getRanks()));
         this.rolePredicate = new RoleContainsKeywordsPredicate(List.of(filterPersonDescriptor.getRoles()));
         this.championPredicate = new ChampionContainsKeywordsPredicate(List.of(filterPersonDescriptor.getChampions()));
+        this.scorePredicate = new ScoreInRangePredicate(filterPersonDescriptor.getScoreThreshold());
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredPersonList(
-                rankPredicate.and(rolePredicate).and(championPredicate)
+                rankPredicate.and(rolePredicate).and(championPredicate).and(scorePredicate)
         );
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
@@ -100,6 +106,7 @@ public class FilterCommand extends Command {
         private Set<Role> roles;
         private Set<Rank> ranks;
         private Set<Champion> champions;
+        private Float scoreThreshold = 0.0F;
 
         public FilterPersonDescriptor() {}
 
@@ -111,6 +118,7 @@ public class FilterCommand extends Command {
             setRoles(toCopy.roles);
             setRanks(toCopy.ranks);
             setChampions(toCopy.champions);
+            setScoreThreshold(toCopy.scoreThreshold);
         }
 
         /**
@@ -183,6 +191,14 @@ public class FilterCommand extends Command {
                     .toArray(String[]::new);
         }
 
+        public void setScoreThreshold(Float scoreThreshold) {
+            this.scoreThreshold = scoreThreshold;
+        }
+
+        public Float getScoreThreshold() {
+            return scoreThreshold;
+        }
+
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -197,7 +213,8 @@ public class FilterCommand extends Command {
             FilterPersonDescriptor otherFilterPersonDescriptor = (FilterPersonDescriptor) other;
             return Objects.equals(roles, otherFilterPersonDescriptor.roles)
                     && Objects.equals(ranks, otherFilterPersonDescriptor.ranks)
-                    && Objects.equals(champions, otherFilterPersonDescriptor.champions);
+                    && Objects.equals(champions, otherFilterPersonDescriptor.champions)
+                    && Objects.equals(scoreThreshold, otherFilterPersonDescriptor.scoreThreshold);
         }
 
         @Override
@@ -206,6 +223,7 @@ public class FilterCommand extends Command {
                     .add("roles", Arrays.toString(getRoles()))
                     .add("ranks", Arrays.toString(getRanks()))
                     .add("champions", Arrays.toString(getChampions()))
+                    .add("scoreThreshold", scoreThreshold != null ? scoreThreshold.toString() : "0.0")
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,5 +14,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_CPM = new Prefix("cpm/");
     public static final Prefix PREFIX_GD15 = new Prefix("gd15/");
     public static final Prefix PREFIX_KDA = new Prefix("kda/");
-
+    public static final Prefix PREFIX_SCORE = new Prefix("s/");
 }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CHAMPION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RANK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCORE;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -31,7 +32,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
     public FilterCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_ROLE, PREFIX_RANK, PREFIX_CHAMPION);
+                ArgumentTokenizer.tokenize(args, PREFIX_ROLE, PREFIX_RANK, PREFIX_CHAMPION, PREFIX_SCORE);
 
         FilterPersonDescriptor filterPersonDescriptor = new FilterPersonDescriptor();
 
@@ -43,6 +44,9 @@ public class FilterCommandParser implements Parser<FilterCommand> {
 
         parseChampionsForFilter(argMultimap.getAllValues(PREFIX_CHAMPION))
                 .ifPresent(filterPersonDescriptor::setChampions);
+
+        parseScoreForFilter(argMultimap.getAllValues(PREFIX_SCORE))
+                .ifPresent(filterPersonDescriptor::setScoreThreshold);
 
         if (!filterPersonDescriptor.isAnyFieldFiltered()) {
             throw new ParseException(
@@ -99,4 +103,28 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         return Optional.of(ParserUtil.parseChampions(championSet));
     }
 
+    /**
+     * Parses {@code Collection<String> scores} into a {@code Float} if {@code scores} is non-empty.
+     * If {@code scores} contain only one element which is an empty string, it will be ignored.
+     * Only the first score is considered; others are ignored.
+     */
+    private Optional<Float> parseScoreForFilter(Collection<String> scores) throws ParseException {
+        assert scores != null;
+
+        if (scores.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String scoreStr = scores.iterator().next().trim();
+        if (scoreStr.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            float score = Float.parseFloat(scoreStr);
+            return Optional.of(score);
+        } catch (NumberFormatException e) {
+            throw new ParseException("Score must be a valid number: " + scoreStr);
+        }
+    }
 }

--- a/src/main/java/seedu/address/model/person/ScoreInRangePredicate.java
+++ b/src/main/java/seedu/address/model/person/ScoreInRangePredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code score} is greater than or equal to the given threshold.
+ */
+public class ScoreInRangePredicate implements Predicate<Person> {
+
+    private final Float threshold;
+
+    public ScoreInRangePredicate(float threshold) {
+        this.threshold = threshold;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getStats().getValue() >= threshold;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ScoreInRangePredicate)) {
+            return false;
+        }
+
+        ScoreInRangePredicate otherPredicate = (ScoreInRangePredicate) other;
+        return Double.compare(threshold, otherPredicate.threshold) == 0;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("threshold", threshold)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Stats.java
+++ b/src/main/java/seedu/address/model/person/Stats.java
@@ -30,8 +30,8 @@ public class Stats {
                     + "Gold difference at 15m must be between -10,000 and 10,000; "
                     + "KDA must be between 0 and 200.";
 
-    /** The textual representation of the average score (formatted as 0.0). */
-    public final String value;
+    /** The average score. */
+    public final float value;
 
     /** Historical list of CS per minute values recorded. */
     public final ArrayList<Float> csPerMinute;
@@ -125,7 +125,7 @@ public class Stats {
     /**
      * Returns the current average performance score as a string formatted to one decimal place.
      */
-    public String getValue() {
+    public float getValue() {
         return this.value;
     }
 
@@ -185,7 +185,7 @@ public class Stats {
 
     @Override
     public String toString() {
-        return value;
+        return String.format("%.1f", value);
     }
 
     @Override
@@ -203,12 +203,12 @@ public class Stats {
         return csPerMinute.equals(otherStats.csPerMinute)
                 && goldDiffAt15.equals(otherStats.goldDiffAt15)
                 && kdaScores.equals(otherStats.kdaScores)
-                && value.equals(otherStats.value);
+                && Float.compare(value, otherStats.value) == 0;
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Float.hashCode(value);
     }
 
     /**
@@ -234,14 +234,14 @@ public class Stats {
     /**
      * Computes the average of all recorded scores and returns it formatted to one decimal place.
      */
-    private String calculateAverageScore() {
+    private float calculateAverageScore() {
         if (scores.isEmpty()) {
-            return "0.0";
+            return 0.0F;
         }
         double total = scores.stream()
                 .reduce(0.0, Double::sum);
 
         double avg = total / scores.size();
-        return String.format("%.1f", avg);
+        return (float) avg;
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FilterPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterPersonDescriptorTest.java
@@ -57,7 +57,8 @@ public class FilterPersonDescriptorTest {
         String expected = FilterPersonDescriptor.class.getCanonicalName() + "{roles="
                 + Arrays.toString(filterPersonDescriptor.getRoles()) + ", ranks="
                 + Arrays.toString(filterPersonDescriptor.getRanks()) + ", champions="
-                + Arrays.toString(filterPersonDescriptor.getChampions()) + "}";
+                + Arrays.toString(filterPersonDescriptor.getChampions()) + ", scoreThreshold="
+                + filterPersonDescriptor.getScoreThreshold() + "}";
         assertEquals(expected, filterPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/StatsTest.java
+++ b/src/test/java/seedu/address/model/person/StatsTest.java
@@ -30,7 +30,7 @@ public class StatsTest {
     @Test
     void defaultConstructor_initialState() {
         Stats stats = new Stats();
-        assertEquals("0.0", stats.getValue());
+        assertEquals(0.0, stats.getValue());
         assertTrue(stats.getCsPerMinute().isEmpty());
         assertTrue(stats.getGoldDiffAt15().isEmpty());
         assertTrue(stats.getKdaScores().isEmpty());
@@ -76,14 +76,14 @@ public class StatsTest {
         assertEquals(1, s1.getKdaScores().size());
         assertEquals(1, s1.getScores().size());
         double e1 = expectedScore(7, 1000, 2.2f);
-        assertEquals(fmt1(e1), s1.getValue());
+        assertEquals((float) e1, s1.getValue());
 
         // Second record
         Stats s2 = s1.addLatestStats("4", "-200", "0.7");
         assertNotEquals(s1, s2);
         assertEquals(2, s2.getCsPerMinute().size());
         double e2avg = (e1 + expectedScore(4, -200, 0.7f)) / 2.0;
-        assertEquals(fmt1(e2avg), s2.getValue());
+        assertEquals((float) e2avg, s2.getValue());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class StatsTest {
         Stats s1 = s0.deleteLatestStats();
         // Equal by content; toString/value should match; equals compares lists+value
         assertEquals(s0, s1);
-        assertEquals("0.0", s1.getValue());
+        assertEquals(0.0, s1.getValue());
     }
 
     @Test
@@ -119,7 +119,7 @@ public class StatsTest {
         Stats s3 = s2.deleteLatestStats(); // should remove e2
         assertEquals(1, s3.getScores().size());
         double e1 = expectedScore(7, 1000, 2.2f);
-        assertEquals(fmt1(e1), s3.getValue());
+        assertEquals((float) e1, s3.getValue());
     }
 
     // Getters (defensive copies)


### PR DESCRIPTION
Filter can now be used on person's score in stats

e.g. `filter s/4.0` gives players who have average scores higher than 4.0

NOTE: Just merge now!

Test cases are not updated, I will add more test cases after v1.4

closes #125 

